### PR TITLE
fix: Update CI workflow versions to remove deprecated runtime warnings

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,7 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-comment: >

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v5.0.2
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
+  TFLINT_VERSION: v0.50.3
 
 jobs:
   collectInputs:
@@ -17,11 +18,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/directories@v1.9.0
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -31,29 +32,39 @@ jobs:
       matrix:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
+      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+      - name: Delete huge unnecessary tools folder
+        run: |
+          rm -rf /opt/hostedtoolcache/CodeQL
+          rm -rf /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk
+          rm -rf /opt/hostedtoolcache/Ruby
+          rm -rf /opt/hostedtoolcache/go
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.4
+        uses: clowdhaus/terraform-min-max@v1.3.0
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
   preCommitMaxVersion:
@@ -61,19 +72,28 @@ jobs:
     runs-on: ubuntu-latest
     needs: collectInputs
     steps:
+      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+      - name: Delete huge unnecessary tools folder
+        run: |
+          rm -rf /opt/hostedtoolcache/CodeQL
+          rm -rf /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk
+          rm -rf /opt/hostedtoolcache/Ruby
+          rm -rf /opt/hostedtoolcache/go
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.4
+        uses: clowdhaus/terraform-min-max@v1.3.0
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           install-hcledit: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - master
     paths:
       - '**/*.tpl'
@@ -19,18 +20,18 @@ jobs:
     if: github.repository_owner == 'terraform-aws-modules'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 18.0.0
+          semantic_version: 23.0.2
           extra_plugins: |
-            @semantic-release/changelog@6.0.0
-            @semantic-release/git@10.0.0
-            conventional-changelog-conventionalcommits@4.6.3
+            @semantic-release/changelog@6.0.3
+            @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@7.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.88.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
@@ -22,8 +21,11 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
+          - '--args=--only=terraform_unused_required_providers'
+      - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ provider "aws" {
 
 module "pricing" {
   source = "terraform-aws-modules/pricing/aws//modules/pricing"
-  
+
   # content can be Terraform state or plan as JSON fetched from any source (see examples)
   content = jsondecode("{\"version\": 4, \"terraform_version\": \"0.14.4\", ...")
 }
@@ -73,7 +73,7 @@ data "local_file" "local_plan" {
 
 module "pricing" {
   source = "terraform-aws-modules/pricing/aws//modules/pricing"
-  
+
   content = jsondecode(data.local_file.local_plan.content)
 }
 ```
@@ -87,7 +87,7 @@ provider "aws" {
 
 module "pricing" {
   source = "terraform-aws-modules/pricing/aws//modules/pricing"
-  
+
   resources = {
     "aws_instance.this#5" = { # Note: This means 5 instances (`count = 5`)
       instanceType = "c5.xlarge"
@@ -126,7 +126,7 @@ end
 
 Set AWS provider's region to `us-east-1` or `sa-east-1` when using [modules/pricing](https://github.com/terraform-aws-modules/terraform-aws-pricing/tree/master/modules/pricing) because AWS Pricing service is only available in these regions.
 
-You can also pass provider explicitly as described in the [official documentation](https://www.terraform.io/docs/modules/providers.html#passing-providers-explicitly). 
+You can also pass provider explicitly as described in the [official documentation](https://www.terraform.io/docs/modules/providers.html#passing-providers-explicitly).
 
 
 #### Debug & development tips

--- a/dev/aws_pricing.md
+++ b/dev/aws_pricing.md
@@ -229,7 +229,7 @@ aws pricing get-attribute-values --region us-east-1 --service-code AmazonRDS --a
 ```
 
 
-aws pricing get-attribute-values --region us-east-1 --service-code AmazonRDS --attribute-name volumeType  
+aws pricing get-attribute-values --region us-east-1 --service-code AmazonRDS --attribute-name volumeType
 ```
 {
     "AttributeValues": [

--- a/examples/fixtures/all-resources/data.tf
+++ b/examples/fixtures/all-resources/data.tf
@@ -1,12 +1,16 @@
 ##################################################################
 # Data sources to get VPC, subnet, security group and AMI details
 ##################################################################
+
 data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_ami" "amazon_linux" {

--- a/examples/fixtures/all-resources/main.tf
+++ b/examples/fixtures/all-resources/main.tf
@@ -144,35 +144,35 @@ resource "aws_elb" "elb" {
     lb_protocol       = "HTTP"
   }
 
-  subnets = data.aws_subnet_ids.all.ids
+  subnets = data.aws_subnets.all.ids
 }
 
 resource "aws_lb" "alb1" {
   load_balancer_type = "application"
-  subnets            = data.aws_subnet_ids.all.ids
+  subnets            = data.aws_subnets.all.ids
 }
 
 resource "aws_alb" "alb2" {
   load_balancer_type = "application"
-  subnets            = data.aws_subnet_ids.all.ids
+  subnets            = data.aws_subnets.all.ids
 }
 
 resource "aws_lb" "nlb" {
   load_balancer_type = "network"
-  subnets            = data.aws_subnet_ids.all.ids
+  subnets            = data.aws_subnets.all.ids
 }
 
 resource "aws_lb" "undefined_type" {
-  subnets = data.aws_subnet_ids.all.ids
+  subnets = data.aws_subnets.all.ids
 }
 
 resource "aws_eip" "nat" {
-  vpc = true
+  domain = "vpc"
 }
 
 resource "aws_nat_gateway" "nat" {
   allocation_id = aws_eip.nat.id
-  subnet_id     = tolist(data.aws_subnet_ids.all.ids)[0]
+  subnet_id     = tolist(data.aws_subnets.all.ids)[0]
 }
 
 #######################################################

--- a/examples/fixtures/all-resources/versions.tf
+++ b/examples/fixtures/all-resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/fixtures/combinations/main.tf
+++ b/examples/fixtures/combinations/main.tf
@@ -5,12 +5,16 @@ provider "aws" {
 ##################################################################
 # Data sources to get VPC, subnet, security group and AMI details
 ##################################################################
+
 data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_ami" "amazon_linux" {
@@ -35,7 +39,7 @@ module "instance_count_2" {
   name          = "instance_count_"
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "t2.micro"
-  subnet_id     = element(data.aws_subnet_ids.all.ids, 0)
+  subnet_id     = element(data.aws_subnets.all.ids, 0)
 
   root_block_device = [
     {
@@ -52,7 +56,7 @@ module "module_count_2" {
   name          = "module_count_"
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "t2.nano"
-  subnet_id     = element(data.aws_subnet_ids.all.ids, 0)
+  subnet_id     = element(data.aws_subnets.all.ids, 0)
 
 }
 
@@ -68,7 +72,7 @@ resource "aws_instance" "nano_count_2" {
 
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "t3.nano"
-  subnet_id     = element(data.aws_subnet_ids.all.ids, 0)
+  subnet_id     = element(data.aws_subnets.all.ids, 0)
 }
 
 ##########
@@ -78,7 +82,7 @@ resource "aws_instance" "small_for_each_fixed" {
 
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "t3.small"
-  subnet_id     = element(data.aws_subnet_ids.all.ids, 0)
+  subnet_id     = element(data.aws_subnets.all.ids, 0)
 
   tags = { Name : each.value }
 }

--- a/modules/cost.modules.tf/README.md
+++ b/modules/cost.modules.tf/README.md
@@ -4,7 +4,7 @@ This module gets cost estimation from `cost.modules.tf` service based on the pro
 
 `cost.modules.tf` is entirely free cost estimation service, which is part of [modules.tf](https://modules.tf) that is currently in active development.
 
-See [repository terraform-cost-estimation](https://github.com/antonbabenko/terraform-cost-estimation) and [terraform-cost-estimation.com](https://www.terraform-cost-estimation.com/) for more information. 
+See [repository terraform-cost-estimation](https://github.com/antonbabenko/terraform-cost-estimation) and [terraform-cost-estimation.com](https://www.terraform-cost-estimation.com/) for more information.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -12,7 +12,6 @@ See [repository terraform-cost-estimation](https://github.com/antonbabenko/terra
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 

--- a/modules/cost.modules.tf/versions.tf
+++ b/modules/cost.modules.tf/versions.tf
@@ -2,11 +2,6 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0"
-    }
-
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"


### PR DESCRIPTION
## Description

- Update CI workflow versions to remove deprecated runtime warnings

## Motivation and Context

- Updates our workflows to use the latest versions
- Removes the `deprecated runtime` warnings from the workflow execution output

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
