### PR TITLE
fix: Update CI workflow versions to latest

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.16.0
-  TFLINT_VERSION: v0.50.3
+  TERRAFORM_DOCS_VERSION: v0.19.0
+  TFLINT_VERSION: v0.53.0
 
 jobs:
   collectInputs:
@@ -45,14 +45,14 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.0
+        uses: clowdhaus/terraform-min-max@v1.3.1
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -61,7 +61,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -88,10 +88,10 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.0
+        uses: clowdhaus/terraform-min-max@v1.3.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -21,10 +21,9 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-          - '--args=--only=terraform_unused_required_providers'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -16,7 +16,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -58,4 +58,4 @@ No inputs.
 | <a name="output_pricing_resources"></a> [pricing\_resources](#output\_pricing\_resources) | Map of provided resources with filters |
 | <a name="output_pricing_total_price_per_hour"></a> [pricing\_total\_price\_per\_hour](#output\_pricing\_total\_price\_per\_hour) | Total price for all resources |
 | <a name="output_pricing_total_price_per_month"></a> [pricing\_total\_price\_per\_month](#output\_pricing\_total\_price\_per\_month) | Total price for all resources per month (730 hours) |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/cost-modules-tf/README.md
+++ b/examples/cost-modules-tf/README.md
@@ -14,7 +14,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -57,4 +57,4 @@ No inputs.
 | <a name="output_price_plan"></a> [price\_plan](#output\_price\_plan) | Costs for local file - plan |
 | <a name="output_price_tfstate"></a> [price\_tfstate](#output\_price\_tfstate) | Costs for local file - state |
 | <a name="output_price_tfstate_with_terraform_remote_state"></a> [price\_tfstate\_with\_terraform\_remote\_state](#output\_price\_tfstate\_with\_terraform\_remote\_state) | Costs for remote state |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/pricing-dev/README.md
+++ b/examples/pricing-dev/README.md
@@ -12,7 +12,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -55,4 +55,4 @@ No inputs.
 | <a name="output_pricing_resources"></a> [pricing\_resources](#output\_pricing\_resources) | Map of provided resources with filters |
 | <a name="output_pricing_total_price_per_hour"></a> [pricing\_total\_price\_per\_hour](#output\_pricing\_total\_price\_per\_hour) | Total price for all resources |
 | <a name="output_pricing_total_price_per_month"></a> [pricing\_total\_price\_per\_month](#output\_pricing\_total\_price\_per\_month) | Total price for all resources per month (730 hours) |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/pricing-resources/README.md
+++ b/examples/pricing-resources/README.md
@@ -16,7 +16,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -53,4 +53,4 @@ No inputs.
 | <a name="output_resources"></a> [resources](#output\_resources) | Map of provided resources with filters |
 | <a name="output_total_price_per_hour"></a> [total\_price\_per\_hour](#output\_total\_price\_per\_hour) | Total price for all resources |
 | <a name="output_total_price_per_month"></a> [total\_price\_per\_month](#output\_total\_price\_per\_month) | Total price for all resources per month (730 hours) |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/pricing-terraform-state-and-plan/README.md
+++ b/examples/pricing-terraform-state-and-plan/README.md
@@ -16,7 +16,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -68,4 +68,4 @@ No inputs.
 | <a name="output_pricing_state_resources"></a> [pricing\_state\_resources](#output\_pricing\_state\_resources) | Map of provided resources with filters |
 | <a name="output_pricing_state_total_price_per_hour"></a> [pricing\_state\_total\_price\_per\_hour](#output\_pricing\_state\_total\_price\_per\_hour) | Total price for all resources |
 | <a name="output_pricing_state_total_price_per_month"></a> [pricing\_state\_total\_price\_per\_month](#output\_pricing\_state\_total\_price\_per\_month) | Total price for all resources per month (730 hours) |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/cost.modules.tf/README.md
+++ b/modules/cost.modules.tf/README.md
@@ -6,7 +6,7 @@ This module gets cost estimation from `cost.modules.tf` service based on the pro
 
 See [repository terraform-cost-estimation](https://github.com/antonbabenko/terraform-cost-estimation) and [terraform-cost-estimation.com](https://www.terraform-cost-estimation.com/) for more information.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -50,4 +50,4 @@ No modules.
 | <a name="output_costs"></a> [costs](#output\_costs) | Total costs |
 | <a name="output_hourly"></a> [hourly](#output\_hourly) | Hourly costs |
 | <a name="output_monthly"></a> [monthly](#output\_monthly) | Monthly costs |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/pricing/README.md
+++ b/modules/pricing/README.md
@@ -29,7 +29,7 @@ add support for new types of resources.
 
 `regions.tf` contains logic for expanding AWS regions map which is expected by Pricing API.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -82,4 +82,4 @@ No modules.
 | <a name="output_resources"></a> [resources](#output\_resources) | Map of provided resources with filters |
 | <a name="output_total_price_per_hour"></a> [total\_price\_per\_hour](#output\_total\_price\_per\_hour) | Total price for all resources per hour |
 | <a name="output_total_price_per_month"></a> [total\_price\_per\_month](#output\_total\_price\_per\_month) | Total price for all resources per month (730 hours) |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## Description

- Update CI workflow versions to latest

## Motivation and Context

- Updates our workflows to use the latest versions
- Removes warnings for Python 3.12 in runners

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
