### PR TITLE
feat!: Bump minimum AWS provider version to 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0](https://github.com/terraform-aws-modules/terraform-aws-pricing/compare/v2.0.3...v3.0.0) (2026-02-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Minimum AWS provider version bumped from v4.0 to v6.0
+
+### Bug Fixes
+
+* Replace deprecated `name` argument with `region` in `aws_region` data source ([#24](https://github.com/terraform-aws-modules/terraform-aws-pricing/issues/24))
+
 ## [2.0.3](https://github.com/terraform-aws-modules/terraform-aws-pricing/compare/v2.0.2...v2.0.3) (2024-03-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### ⚠ BREAKING CHANGES
 
 * Minimum AWS provider version bumped from v4.0 to v6.0
+* Updated `terraform-aws-modules/ec2-instance/aws` module in fixtures from v3.0 to v6.0
 
 ### Bug Fixes
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,7 +22,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
 
     local = {

--- a/examples/cost-modules-tf/README.md
+++ b/examples/cost-modules-tf/README.md
@@ -20,7 +20,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 
 ## Providers

--- a/examples/cost-modules-tf/versions.tf
+++ b/examples/cost-modules-tf/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
 
     local = {

--- a/examples/fixtures/all-resources/versions.tf
+++ b/examples/fixtures/all-resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/fixtures/combinations/main.tf
+++ b/examples/fixtures/combinations/main.tf
@@ -34,24 +34,22 @@ data "aws_ami" "amazon_linux" {
 
 module "instance_count_2" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 3.0"
+  version = "~> 6.0"
 
   name          = "instance_count_"
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "t2.micro"
   subnet_id     = element(data.aws_subnets.all.ids, 0)
 
-  root_block_device = [
-    {
-      volume_type = "gp2"
-      volume_size = 10
-    },
-  ]
+  root_block_device = {
+    volume_type = "gp2"
+    volume_size = 10
+  }
 }
 
 module "module_count_2" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 3.0"
+  version = "~> 6.0"
 
   name          = "module_count_"
   ami           = data.aws_ami.amazon_linux.id

--- a/examples/fixtures/combinations/versions.tf
+++ b/examples/fixtures/combinations/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/fixtures/combinations/versions.tf
+++ b/examples/fixtures/combinations/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/examples/pricing-dev/README.md
+++ b/examples/pricing-dev/README.md
@@ -18,7 +18,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 
 ## Providers

--- a/examples/pricing-dev/versions.tf
+++ b/examples/pricing-dev/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
 
     local = {

--- a/examples/pricing-resources/README.md
+++ b/examples/pricing-resources/README.md
@@ -22,7 +22,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 

--- a/examples/pricing-resources/versions.tf
+++ b/examples/pricing-resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/pricing-terraform-state-and-plan/README.md
+++ b/examples/pricing-terraform-state-and-plan/README.md
@@ -22,7 +22,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 
 ## Providers

--- a/examples/pricing-terraform-state-and-plan/versions.tf
+++ b/examples/pricing-terraform-state-and-plan/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
 
     local = {

--- a/modules/pricing/README.md
+++ b/modules/pricing/README.md
@@ -35,13 +35,13 @@ add support for new types of resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 

--- a/modules/pricing/regions.tf
+++ b/modules/pricing/regions.tf
@@ -6,7 +6,7 @@ data "aws_region" "one" {
   #  for_each = data.aws_regions.all.names
   for_each = { for k, v in data.aws_regions.all.names : k => v if !contains(["ap-northeast-3"], k) }
 
-  name = each.value
+  region = each.value
 }
 
 locals {

--- a/modules/pricing/versions.tf
+++ b/modules/pricing/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
## Description

This PR bumps the AWS provider to v6.0 as happened in various other modules, since the `name` parameter has been replaced by `region`. The old version kept issuing warnings. This PR fixes that.

### ⚠ BREAKING CHANGES

* Minimum AWS provider version bumped from v4.0 to v6.0

### Bug Fixes

* Replace deprecated `name` argument with `region` in `aws_region` data source ([#24](https://github.com/terraform-aws-modules/terraform-aws-pricing/issues/24))

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes

### ⚠ BREAKING CHANGES

* Minimum AWS provider version bumped from v4.0 to v6.0

## How Has This Been Tested?
These changes have been tested in my fork on live infra and work as expected.
